### PR TITLE
Fix env var parsing

### DIFF
--- a/utils/defaults/defaults.go
+++ b/utils/defaults/defaults.go
@@ -89,7 +89,7 @@ var (
 
 func init() {
 	if rolloutVerifyInterval, ok := os.LookupEnv(EnvVarRolloutVerifyRetryInterval); ok {
-		if interval, err := strconv.ParseInt(rolloutVerifyInterval, 10, 32); err != nil {
+		if interval, err := strconv.ParseInt(rolloutVerifyInterval, 10, 32); err == nil {
 			rolloutVerifyRetryInterval = time.Duration(interval) * time.Second
 		}
 	}

--- a/utils/defaults/defaults_test.go
+++ b/utils/defaults/defaults_test.go
@@ -426,3 +426,17 @@ func TestSetDefaults(t *testing.T) {
 	SetDescribeTagsLimit(2)
 	assert.Equal(t, 2, GetDescribeTagsLimit())
 }
+
+func TestRolloutVerifyRetryIntervalFromEnv(t *testing.T) {
+	t.Setenv(EnvVarRolloutVerifyRetryInterval, "15")
+	rolloutVerifyRetryInterval = 10 * time.Second
+	init()
+	assert.Equal(t, 15*time.Second, GetRolloutVerifyRetryInterval())
+}
+
+func TestRolloutVerifyRetryIntervalInvalidEnv(t *testing.T) {
+	t.Setenv(EnvVarRolloutVerifyRetryInterval, "bad")
+	rolloutVerifyRetryInterval = 10 * time.Second
+	init()
+	assert.Equal(t, 10*time.Second, GetRolloutVerifyRetryInterval())
+}


### PR DESCRIPTION
## Summary
- use parsed retry interval if conversion succeeds
- test env var handling for rollout verify retry interval

## Testing
- `go test ./...` *(fails: no route to host)*