### PR TITLE
Fix progress deadline stuck with Istio delays

### DIFF
--- a/rollout/trafficrouting/istio/istio_test.go
+++ b/rollout/trafficrouting/istio/istio_test.go
@@ -3101,7 +3101,7 @@ func TestUpdateHashNoReadyReplicaSets(t *testing.T) {
 	client.ClearActions()
 
 	err := r.UpdateHash("abc123", "def456")
-	assert.Error(t, err, "delaying destination rule switch: ReplicaSet ReplicaSetForTesting not fully available")
+	assert.NoError(t, err)
 	actions := client.Actions()
 	assert.Len(t, actions, 0)
 }


### PR DESCRIPTION
## Summary
- don't stop reconciliation when Istio traffic routing delays DestinationRule updates
- clarify test expectation when no replica sets are ready
- document fix in comments